### PR TITLE
Fix JS Content-Type in some Windows environments

### DIFF
--- a/server.go
+++ b/server.go
@@ -217,7 +217,7 @@ func (s *Server) serve(rw http.ResponseWriter, req *http.Request, fn, suf, enc s
 	}
 	
 	// This is used to enforce application/javascript MIME on Windows (https://github.com/golang/go/issues/32350)
-	if strings.HasSuffix(r.URL.Path, ".js") {
+	if strings.HasSuffix(req.URL.Path, ".js") {
 		ctype = "application/javascript"
 	}
 

--- a/server.go
+++ b/server.go
@@ -215,6 +215,11 @@ func (s *Server) serve(rw http.ResponseWriter, req *http.Request, fn, suf, enc s
 	if ctype == "" {
 		ctype = "application/octet-stream" // Prevent unreliable Content-Type detection on compressed data.
 	}
+	
+	// This is used to enforce application/javascript MIME on Windows (https://github.com/golang/go/issues/32350)
+	if strings.HasSuffix(r.URL.Path, ".js") {
+		ctype = "application/javascript"
+	}
 
 	rw.Header().Set("Content-Type", ctype)
 	rw.Header().Set("Etag", info.hash)


### PR DESCRIPTION
We ran into this little bug while deploying statigz. Some unidentified but popular Windows software sets registry entries with incorrect .js MIME-type. This sets the official .js mime-type as an override. 

Also see https://github.com/golang/go/issues/32350

```
// TypeByExtension returns the MIME type associated with the file extension ext.
// The extension ext should begin with a leading dot, as in ".html".
...
// On Windows, MIME types are extracted from the registry.
```