### PR TITLE
Trim the slice returned by the brotli encoder

### DIFF
--- a/brotli/encoding.go
+++ b/brotli/encoding.go
@@ -31,7 +31,7 @@ func AddEncoding(server *statigz.Server) {
 				return nil, err
 			}
 
-			return res.Bytes(), nil
+			return append([]byte{}, res.Bytes()...), nil
 		},
 	}
 


### PR DESCRIPTION
bytes.Buffer can over-allocate; clone the slice so that it uses its minimum possible memory footprint