### PR TITLE
use BestCompression in GzipEncoding

### DIFF
--- a/server.go
+++ b/server.go
@@ -474,7 +474,10 @@ func GzipEncoding() Encoding {
 		},
 		Encoder: func(r io.Reader) ([]byte, error) {
 			res := bytes.NewBuffer(nil)
-			w := gzip.NewWriter(res)
+			w, err := gzip.NewWriterLevel(res, gzip.BestCompression)
+			if err != nil {
+				return nil, err
+			}
 
 			if _, err := io.Copy(w, r); err != nil {
 				return nil, err


### PR DESCRIPTION
This probably won't matter for modern browsers as they can use brotli/zstd, but there are still many curl installations that only support gzip (the same is also true for the default HTTP client in Go).